### PR TITLE
adding support for LRU caches

### DIFF
--- a/src/levelDB.mli
+++ b/src/levelDB.mli
@@ -88,6 +88,7 @@ val open_db :
   ?max_open_files:int ->
   ?block_size:int -> ?block_restart_interval:int ->
   ?comparator:comparator ->
+  ?cache_size:int ->
   string -> db
 
 (** Close the database. All further operations on it will fail.
@@ -207,7 +208,7 @@ sig
     * will be invalidated and further operations will fail.  The returned
     * iterator needs not be closed manually, for it will be closed in its
     * finalizer. *)
-  val make : db -> iterator
+  val make : ?fill_cache:bool -> db -> iterator
 
   (** Close the iterator. Further operations on it will fail. Note that
     * the iterator fill be closed automatically in its finalizer if this

--- a/test/benchmark.ml
+++ b/test/benchmark.ml
@@ -128,13 +128,13 @@ let () =
 
   let compact () =
     print_endline "Compacting...";
-    let db = LDB.open_db "/tmp/ldb" in
+    let db = LDB.open_db ~cache_size:10 "/tmp/ldb" in
       LDB.compact_range db ~from_key:(Some "") ~to_key:None;
       LDB.close db;
       print_endline "DONE" in
 
   let print_stats () =
-    let db = LDB.open_db "/tmp/ldb" in
+    let db = LDB.open_db ~cache_size:10 "/tmp/ldb" in
       begin match LDB.get_property db "leveldb.stats" with
           None -> ()
         | Some x -> print_newline (); print_endline x
@@ -171,4 +171,3 @@ let () =
         `O ("rev scan", bm_iter_rev_scan);
         `E print_stats;
       ]
-


### PR DESCRIPTION
This little commit adds

  1) a ~cache_size optional argument to the open_db function. if present, it is the size in Mb of the LRU cache
  2) a ~fill_cache optional argument to the Iterator.make function. default value is true, which means that iter will update the cache if there is one. 

UT's passed. It's a quick hack hopefully clean enough to be merged. Thanks!
