### PR TITLE
Fix bug: fix initialization of snapshot ids

### DIFF
--- a/src/leveldb_stubs.cc
+++ b/src/leveldb_stubs.cc
@@ -832,6 +832,7 @@ ldb_snapshot_make(value t)
  const leveldb::Snapshot* snapshot = db->GetSnapshot();
  ret = caml_alloc_custom(&ldb_snapshot_ops, sizeof(ldb_snapshot), 0, 1);
  ldb_snapshot *_ret = UNWRAP_SNAPSHOT(ret);
+ _ret->id = ++wrapped_val_id;
  _ret->db = db;
  _ret->snapshot = snapshot;
  _ret->closed = false;


### PR DESCRIPTION
The id field of snapshots was uninitialized (I detect this problem using valgrind). The hash function actually use this id as a key when storing snapshots in a Weak Hashtbl, so it is interresting to fix it for performances.
