### PR TITLE
Fix memory leaks from returned status when NotFound is raised by "get" functions.

### DIFF
--- a/src/leveldb_stubs.cc
+++ b/src/leveldb_stubs.cc
@@ -404,7 +404,7 @@ ldb_get(value t, value k)
  RELEASE_HANDLE(t);
  caml_leave_blocking_section();
 
- if(status.IsNotFound()) { v.~string(); RAISE_NOT_FOUND; }
+ if(status.IsNotFound()) { v.~string(); status.~Status(); RAISE_NOT_FOUND; }
 
  CHECK_ERROR_AND_CLEANUP(status, { v.~string(); });
 
@@ -871,7 +871,7 @@ ldb_snapshot_get(value t, value k)
  RELEASE_SNAPSHOT(t);
  caml_leave_blocking_section();
 
- if(status.IsNotFound()) { v.~string(); RAISE_NOT_FOUND; }
+ if(status.IsNotFound()) { v.~string(); status.~Status(); RAISE_NOT_FOUND; }
 
  CHECK_ERROR_AND_CLEANUP(status, { v.~string(); });
 


### PR DESCRIPTION
The **status** is not freed when the **Not_found** exception is raised by the two functions **ldb_get** and **ldb_snapshot_get**, involving memory leaks in the C heap.

This suggested commit fix the problem.

However, other memory leaks may occur when errors are encountered. In particular, the **CHECK_ERROR_AND_CLEANUP** macro does'nt correctly free the status before raising a **Failure** exception. These memory leaks are less important since they don't happen in "normal" cases, but should be also fixed in a similar way. A temporary buffer may be necessary to store the error message in that case.
