### PR TITLE
Update for OCaml 4.06.0

### DIFF
--- a/opam
+++ b/opam
@@ -14,6 +14,7 @@ install: [["omake" "install" "prefix=%{prefix}%"]]
 build-test: [["omake" "test"] { ounit:installed } ]
 remove: [["ocamlfind" "remove" "leveldb"]]
 
+available: [ocaml-version >= "4.03"]
 depends: [
   "ocamlfind" {build}
   "omake" {build}

--- a/src/levelDB.ml
+++ b/src/levelDB.ml
@@ -26,8 +26,8 @@ type comparator
 type _env
 type env = _env option
 
-external hash_snapshot_ : snapshot_ -> int = "ldb_snapshot_hash" "noalloc"
-external hash_iterator_ : iterator_ -> int = "ldb_iterator_hash" "noalloc"
+external hash_snapshot_ : snapshot_ -> int = "ldb_snapshot_hash" [@@noalloc]
+external hash_iterator_ : iterator_ -> int = "ldb_iterator_hash" [@@noalloc]
 
 module RMutex =
 struct
@@ -117,7 +117,7 @@ external destroy : string -> bool = "ldb_destroy"
 external repair : string -> bool = "ldb_repair"
 
 external lexicographic_comparator : unit -> comparator =
-  "ldb_lexicographic_comparator" "noalloc"
+  "ldb_lexicographic_comparator" [@@noalloc]
 
 let lexicographic_comparator = lexicographic_comparator ()
 
@@ -201,7 +201,7 @@ struct
 
   external delete_substring_unsafe :
     writebatch -> string -> int -> int -> unit =
-      "ldb_writebatch_delete_substring_unsafe" "noalloc"
+      "ldb_writebatch_delete_substring_unsafe" [@@noalloc]
 
   let delete b k = delete_substring_unsafe b k 0 (String.length k)
 
@@ -228,7 +228,7 @@ struct
   external next_ : iterator_ -> unit = "ldb_it_next"
   external prev_: iterator_ -> unit = "ldb_it_prev"
 
-  external valid_ : iterator_ -> bool = "ldb_it_valid" "noalloc"
+  external valid_ : iterator_ -> bool = "ldb_it_valid" [@@noalloc]
 
   external key_unsafe_ : iterator_ -> bytes -> int = "ldb_it_key_unsafe"
   external value_unsafe_ : iterator_ -> bytes -> int = "ldb_it_value_unsafe"

--- a/src/levelDB.mli
+++ b/src/levelDB.mli
@@ -254,10 +254,10 @@ sig
     * updates the reference.
     * @raise Error if the iterator is not {!valid}
     * @return length of the key *)
-  val fill_key : iterator -> string ref -> int
+  val fill_key : iterator -> bytes ref -> int
 
   (** Similar to {!fill_key}, but returning the value. *)
-  val fill_value : iterator -> string ref -> int
+  val fill_value : iterator -> bytes ref -> int
 
   (** Return the key part of the binding pointer to by the iterator.
     * @raise Error if the iterator is not {!valid}. *)

--- a/test/benchmark.ml
+++ b/test/benchmark.ml
@@ -57,7 +57,7 @@ let bm_iter_value db ?seed n =
     time
       (fun () ->
          let it = LDB.Iterator.make db in
-         let v = ref "" in
+         let v = ref Bytes.empty in
            for i = 1 to n do
              let k = FRAND.int r in
              let key = string_of_int k in
@@ -103,8 +103,8 @@ let bm_iter_scan_aux init next db ?seed n =
     time
       (fun () ->
          let it = LDB.Iterator.make db in
-         let k = ref "" in
-         let v = ref "" in
+         let k = ref Bytes.empty in
+         let v = ref Bytes.empty in
            init it;
            while LDB.Iterator.valid it do
              ignore (LDB.Iterator.fill_key it k);


### PR DESCRIPTION
In 4.06.0 -safe-string is turned on by default. This fixes the various problems.
Note that the `fill_key` and `fill_value` functions had to be turned into using bytes according to their behavior.
For compatibility reason, it could be possible to keep using strings (and basically be equivalent to `get_key`) and add a `new_fill_key` function instead using bytes.

I think breaking code doing the wrong assumption is the way to go, but you obviously have the last call on it.