### PR TITLE
Fix build for leveldb >= 1.21

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -25,4 +25,5 @@
    (>= 2.0))
   (ounit2 :with-test)
   (odoc :with-doc)
-  conf-leveldb))
+  conf-leveldb
+   ( >= 2.0)))

--- a/dune-project
+++ b/dune-project
@@ -25,5 +25,5 @@
    (>= 2.0))
   (ounit2 :with-test)
   (odoc :with-doc)
-  conf-leveldb
-   ( >= 2.0)))
+  (conf-leveldb
+   (>= 2.0))))

--- a/leveldb.opam
+++ b/leveldb.opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "2.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
-  "conf-leveldb"
+  "conf-leveldb" { >= "2.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,7 @@
  (wrapped false)
  (foreign_stubs
   (language cxx)
+  (flags (:standard -std=gnu++11))
   (names leveldb_stubs))
  (c_library_flags -lleveldb -lstdc++)
  (libraries threads))


### PR DESCRIPTION
I sent a related PR to opam-repository to update conf-leveldb here: https://github.com/ocaml/opam-repository/pull/19114

[Since LevelDb >= 1.21, C++ 11 is required](https://github.com/google/leveldb/releases/tag/1.21) 

This PR add `-std=c++11` to build command .